### PR TITLE
Added texture set JSON generator plugin

### DIFF
--- a/plugins/TextureSetJsonGenerator/README.md
+++ b/plugins/TextureSetJsonGenerator/README.md
@@ -1,0 +1,32 @@
+# Minecraft Texture Set Generator
+
+> See [Minecraft's Texture Set Documentation](https://help.minecraft.net/hc/en-us/articles/360051308931-Minecraft-Texture-Set-Documentation) for more details about `.texture_set.json` files.
+
+## [bridge.](https://bridge-core.github.io/) Plugin
+
+### Usage
+
+#### Enter texture name in search bar.
+
+  - A list of terrain texture names is loaded into a auto-complete list.
+
+#### Optionally customize texture set output
+
+  - Base layer, MER layer, and normal map layers are automatically filled to match terrain texture name in the search bar.
+
+  - Layer values can be individually modified by changing the _Base layer_, _MER map_ and _Depth map_ fields.
+
+  - The automatically-filled texture name remains in the auto-completion list.
+
+  - Base layer and MER layers can use a uniform color instead of a terrain texture name. Click the paint bucket icon to open a color picker.
+
+  > **TODO:**
+  > Allow user to specify uniform color's output format.
+
+  - Specify if the depth map is a normal map (default) or a heightmap by selecting a value from the dropdown menu next to the field.
+
+  - Leave a field's value empty to omit the layer from the texture set output.
+
+#### Save texture set output
+
+  - Click the _Save_ button to save the generated `.texture_set.json` file to the resource pack `textures/blocks/` directory.

--- a/plugins/TextureSetJsonGenerator/manifest.json
+++ b/plugins/TextureSetJsonGenerator/manifest.json
@@ -1,0 +1,11 @@
+{
+	"author": "jasonjgardner",
+	"id": "e8a0c9f8-0baa-44b0-9391-a6e731481c10",
+	"icon": "mdi-buffer",
+	"version": "1.0.0",
+	"name": "Texture Set Generator",
+	"link": "https://github.com/jasonjgardner/bridge-texture-set-generator",
+	"description": "Easily generate, customize and save .texture_set.json files",
+	"target": "v2",
+	"tags": ["Utility"]
+}

--- a/plugins/TextureSetJsonGenerator/scripts/textureSetGenerator.js
+++ b/plugins/TextureSetJsonGenerator/scripts/textureSetGenerator.js
@@ -1,0 +1,9 @@
+const { create } = await require('@bridge/sidebar')
+const { TextureSetGenerator } = await require('@bridge/ui')
+
+create({
+	id: 'co.jasongardner.textureSetGenerator',
+	displayName: 'Texture Set Generator',
+	icon: 'mdi-buffer ',
+	component: TextureSetGenerator,
+})

--- a/plugins/TextureSetJsonGenerator/scripts/textureSetGenerator.js
+++ b/plugins/TextureSetJsonGenerator/scripts/textureSetGenerator.js
@@ -4,6 +4,6 @@ const { TextureSetGenerator } = await require('@bridge/ui')
 create({
 	id: 'co.jasongardner.textureSetGenerator',
 	displayName: 'Texture Set Generator',
-	icon: 'mdi-buffer ',
+	icon: 'mdi-buffer',
 	component: TextureSetGenerator,
 })

--- a/plugins/TextureSetJsonGenerator/ui/TextureSetGenerator.vue
+++ b/plugins/TextureSetJsonGenerator/ui/TextureSetGenerator.vue
@@ -1,0 +1,99 @@
+<template>
+	<div class="d-flex flex-column">
+		<div class="d-flex align-center">
+			<v-combobox
+				v-model="blockName"
+				:items="blockList"
+				label="Generate texture set for block"
+				clearable
+				auto-select-first
+				solo
+			></v-combobox>
+		</div>
+
+		<TextureSetOutput
+			v-if="blockName"
+			:block="blockName"
+			@save="onSave"
+			@reset="onReset"
+		/>
+
+		<v-snackbar :value="savedFile && savedFile.length">
+			{{ savedFile }} saved
+
+			<template v-slot:action="{ attrs }">
+				<v-btn
+					color="pink"
+					text
+					v-bind="attrs"
+					@click="savedFile = false"
+				>
+					Close
+				</v-btn>
+			</template>
+		</v-snackbar>
+	</div>
+</template>
+
+<script>
+const { readJSON } = await require('@bridge/fs')
+const { createError } = await require('@bridge/notification')
+const { getCurrentRP } = await require('@bridge/env')
+const { TextureSetOutput } = await require('@bridge/ui')
+
+export default {
+	name: 'TextureSetGenerator',
+	components: {
+		TextureSetOutput,
+	},
+	data: () => ({
+		resetOnSave: false,
+		savedFile: false,
+		blockName: '',
+		blockList: [],
+	}),
+	mounted() {
+		this.updateBlocksList()
+	},
+	methods: {
+		async updateBlocksList() {
+			const terrainTextureFile = `${getCurrentRP()}/textures/terrain_texture.json`
+			const { texture_data: textureData } = await readJSON(
+				terrainTextureFile
+			)
+
+			if (!textureData) {
+				createError(
+					new Error(
+						`Could not read textures in ${terrainTextureFile}`
+					)
+				)
+				return
+			}
+
+			this.blockList = [
+				...new Set(
+					Object.keys(textureData)
+						.map((k) => {
+							const { textures } = textureData[k]
+							return textures || ''
+						})
+						.flat()
+						.map((v) => v.substring(v.lastIndexOf('/') + 1))
+						.filter((v) => v && `${v}`.length > 0)
+				),
+			]
+		},
+		onReset() {
+			this.blockName = ''
+		},
+		onSave(savedFile) {
+			this.savedFile = savedFile
+
+			if (this.resetOnSave) {
+				this.onReset()
+			}
+		},
+	},
+}
+</script>

--- a/plugins/TextureSetJsonGenerator/ui/TextureSetOutput.vue
+++ b/plugins/TextureSetJsonGenerator/ui/TextureSetOutput.vue
@@ -1,0 +1,359 @@
+<template>
+	<div>
+		<v-card>
+			<v-card-title v-text="filename"></v-card-title>
+			<v-card-subtitle v-text="fullPath"></v-card-subtitle>
+			<v-divider></v-divider>
+			<v-sheet class="pa-5" dark>
+				<v-btn rounded right absolute @click="saveTextureSet">
+					JSON Output
+				</v-btn>
+
+				<pre class="select-all">{{ textureSetJson }}</pre>
+			</v-sheet>
+			<v-divider></v-divider>
+			<v-list-item>
+				<v-list-item-content>
+					<v-select
+						v-model="formatVersion"
+						:items="formatVersionMenu"
+						label="Format Version"
+					></v-select>
+				</v-list-item-content>
+			</v-list-item>
+			<v-divider></v-divider>
+			<v-list-item>
+				<v-list-item-content>
+					<v-combobox
+						v-model="displayValue.color"
+						label="Base layer"
+						:items="[block, ...existingTextures.base]"
+						@input="(v) => onLayerInput('color', v)"
+					>
+						<template v-slot:append-outer>
+							<v-btn icon @click.stop="openColorPicker(false)">
+								<v-icon color="grey lighten-1"
+									>mdi-format-color-fill</v-icon
+								>
+							</v-btn>
+						</template>
+					</v-combobox>
+				</v-list-item-content>
+			</v-list-item>
+
+			<v-list-item>
+				<v-list-item-content>
+					<v-combobox
+						v-model="displayValue.mer"
+						label="MER map"
+						:items="[...merSuggestions, ...existingTextures.mers]"
+						@input="(v) => onLayerInput('mer', v)"
+					>
+						<template v-slot:append-outer>
+							<v-btn icon @click.stop="openColorPicker(true)">
+								<v-icon color="grey lighten-1"
+									>mdi-format-color-fill</v-icon
+								>
+							</v-btn>
+
+							<v-btn icon @click="onLayerInput('mer', null)">
+								<v-icon color="grey lighten-1"
+									>mdi-close</v-icon
+								>
+							</v-btn>
+						</template>
+					</v-combobox>
+				</v-list-item-content>
+			</v-list-item>
+
+			<v-list-item>
+				<v-list-item-content>
+					<v-combobox
+						v-model="
+							inputValue[useNormalMap ? 'normal' : 'heightmap']
+						"
+						label="Depth map"
+						:items="[
+							...depthMapSuggestions,
+							...existingTextures.depth,
+						]"
+					>
+						<template v-slot:append-outer>
+							<v-btn
+								icon
+								@click="
+									inputValue[
+										useNormalMap ? 'normal' : 'heightmap'
+									] = null
+								"
+							>
+								<v-icon color="grey lighten-1"
+									>mdi-close</v-icon
+								>
+							</v-btn>
+						</template>
+					</v-combobox>
+				</v-list-item-content>
+				<v-list-item-action>
+					<v-menu open-on-hover close-on-click close-on-content-click>
+						<template v-slot:activator="{ on, attrs }">
+							<v-btn
+								small
+								color="secondary"
+								v-bind="attrs"
+								v-on="on"
+							>
+								{{ !useNormalMap ? 'Heightmap' : 'Normal map' }}
+								<v-icon right>mdi-chevron-down</v-icon>
+							</v-btn>
+						</template>
+						<v-list>
+							<v-list-item @click="useNormalMap = true">
+								<v-list-item-title
+									>Normal Map</v-list-item-title
+								>
+							</v-list-item>
+							<v-list-item @click="useNormalMap = false">
+								<v-list-item-title>Heightmap</v-list-item-title>
+							</v-list-item>
+						</v-list>
+					</v-menu>
+				</v-list-item-action>
+			</v-list-item>
+			<v-divider></v-divider>
+			<v-card-actions>
+				<v-spacer></v-spacer>
+				<v-btn text @click="$emit('reset')">Reset</v-btn>
+				<v-btn text color="primary" @click="saveTextureSet">Save</v-btn>
+			</v-card-actions>
+		</v-card>
+
+		<v-dialog v-model="showColorPicker" max-width="320">
+			<v-card>
+				<v-card-title class="headline">Uniform Color</v-card-title>
+				<v-card-subtitle>{{
+					pickMer ? 'MER' : 'Base'
+				}}</v-card-subtitle>
+				<v-card-text>
+					<v-color-picker @input="colorPickerInput"></v-color-picker>
+				</v-card-text>
+				<v-divider></v-divider>
+				<v-card-actions>
+					<v-spacer></v-spacer>
+					<v-btn text color="primary" @click="closeColorPicker"
+						>Close</v-btn
+					>
+				</v-card-actions>
+			</v-card>
+		</v-dialog>
+	</div>
+</template>
+
+<script>
+const { writeJSON, readFilesFromDir } = await require('@bridge/fs')
+const { createError } = await require('@bridge/notification')
+const { getCurrentRP } = await require('@bridge/env')
+const ahex = (v) => `${v}`.substr(7, 2) + `${v}`.substr(1, 6)
+const getFormatVersions = () => ['1.16.100']
+
+const getExistingTextures = async (endsWithSearch = '_normal') => {
+	const existing = await readFilesFromDir(getCurrentRP() + '/textures/blocks')
+	const baseNames = existing
+		.filter(({ name }) => name.match(/\.(png|tga|gif|jpe?g)$/i))
+		.map(({ name }) => name.substr(0, name.indexOf('.')))
+
+	const mers = baseNames.filter((name) => name.endsWith('_mer'))
+	const depth = baseNames.filter((name) => name.endsWith(endsWithSearch))
+	const base = baseNames.filter(
+		(name) => !mers.includes(name) && !depth.includes(name)
+	)
+
+	return {
+		base,
+		mers,
+		depth,
+	}
+}
+
+export default {
+	name: 'TextureSetOutput',
+	props: {
+		block: {
+			type: String,
+			required: true,
+			default: '',
+			validator: (v) => `${v}`.match(/^[a-z]+[a-z0-9_]*[a-z0-9]*$/i),
+		},
+	},
+	data: () => ({
+		formatVersion: '',
+		colorValue: {
+			color: null,
+			mer: null,
+		},
+		inputValue: {},
+		displayValue: {
+			color: null,
+			mer: null,
+		},
+		showColorPicker: false,
+		pickMer: false,
+		useColorValues: {
+			color: false,
+			mer: false,
+		},
+		useNormalMap: true,
+		existingTextures: {
+			base: [],
+			mers: [],
+			depth: [],
+		},
+	}),
+	async mounted() {
+		this.inputValue = {
+			color: `${this.block}`,
+			mer: `${this.block}_mer`,
+			normal: `${this.block}_normal`,
+			heightmap: `${this.block}_heightmap`,
+		}
+		this.displayValue = this.inputValue
+		this.formatVersion = getFormatVersions()[0]
+
+		this.existingTextures = await getExistingTextures(
+			this.useNormalMap ? '_normal' : '_heightmap'
+		)
+	},
+	methods: {
+		async saveTextureSet() {
+			try {
+				await writeJSON(this.fullPath, this.textureSetData, true)
+				this.$emit('save', this.fullPath)
+			} catch (err) {
+				createError(err)
+			}
+		},
+		openColorPicker(isMer) {
+			this.pickMer = isMer === true
+			this.showColorPicker = true
+		},
+		closeColorPicker() {
+			this.pickMer = false
+			this.showColorPicker = false
+		},
+		colorPickerInput({ rgba, hexa, hex }) {
+			let rgb = Object.values(rgba)
+
+			if (this.pickMer) {
+				this.useColorValues.mer = true
+				rgb.length = 3
+				this.colorValue.mer = rgb
+				this.displayValue.mer = hex
+				return
+			}
+
+			this.useColorValues.color = true
+			this.displayValue.color = '#' + ahex(hexa)
+			this.colorValue.color = rgb
+		},
+		onLayerInput(layer, val) {
+			this.useColorValues[layer] = false
+			this.inputValue[layer] = val
+		},
+	},
+	computed: {
+		filename() {
+			return `${this.block.toLowerCase()}.texture_set.json`
+		},
+		fullPath() {
+			const dir = 'blocks' /// TODO: Allow selecting other directories
+			return `${getCurrentRP()}/textures/${dir}/${this.filename}`
+		},
+		textureSetData() {
+			const getLayerValue = (layer) => {
+				const key = this.useColorValues[layer]
+					? 'colorValue'
+					: 'inputValue'
+				return this[key][layer]
+			}
+
+			const textureSet = {
+				color: getLayerValue('color') || this.inputValue.color,
+			}
+
+			const mer = getLayerValue('mer') || this.inputValue.mer
+
+			if (mer && mer.length > 0) {
+				textureSet.metalness_emissive_roughness = mer
+			}
+
+			if (this.useNormalMap && this.inputValue.normal) {
+				textureSet.normal = `${this.inputValue.normal}`
+			}
+
+			if (!this.useNormalMap && this.inputValue.heightmap) {
+				textureSet.heightmap = this.inputValue.heightmap
+			}
+
+			return {
+				format_version: this.formatVersion,
+				'minecraft:texture_set': textureSet,
+			}
+		},
+		textureSetJson() {
+			return JSON.stringify(this.textureSetData, null, 2)
+		},
+		merSuggestions() {
+			const list = [`${this.block}_mer`]
+
+			if (!this.useColorValues.color) {
+				list.push(`${this.inputValue.color}_mer`)
+			}
+
+			return list
+		},
+		depthMapSuggestions() {
+			let suffix = 'heightmap'
+
+			const suggestions = []
+
+			if (this.useNormalMap) {
+				suffix = 'normal'
+				suggestions.push(`${this.block}_n`)
+			}
+
+			suggestions.push(`${this.block}_${suffix}`)
+
+			if (
+				!this.useColorValues &&
+				this.inputValue.color &&
+				this.inputValue.color.length > 1
+			) {
+				suggestions.push(`${this.inputValue.color}_${suffix}`)
+			}
+
+			return suggestions
+		},
+		formatVersionMenu: () => getFormatVersions(),
+	},
+}
+</script>
+
+<style scoped>
+@keyframes select {
+	to {
+		user-select: text;
+	}
+}
+
+.select-all {
+	user-select: all;
+}
+
+.select-all:focus {
+	animation: select 100ms step-end forwards;
+}
+
+.pointer-none {
+	pointer-events: none;
+}
+</style>


### PR DESCRIPTION
### .texture_set.json Generator Plugin
[GitHub repo](https://github.com/jasonjgardner/bridge-texture-set-generator)

- Can generate and save .texture_set.json files for existing terrain textures
- Uses texture names from RP in auto-completions
- Also accepts user input for texture set layer values
- Uniform color values can be provided for the base and MER layers by clicking the paint can icon to the right of the input
- MER and depth map layers can be omitted by clicking the "X" icon to the right of the inputs

#### TODO
Features to include in future updates:
- Allow user to define format of uniform color values
- Provide more labels or instructions
- Load plugin in tab instead of sidebar modal