### PR TITLE
Connectable Block component v1.1.0

### DIFF
--- a/plugins/ConnectableBlock/components/block/connectable.ts
+++ b/plugins/ConnectableBlock/components/block/connectable.ts
@@ -9,11 +9,11 @@ export default defineComponent(({ name, template, schema }) => {
 		],
 		properties: {
 			tag: {
-				description: 'The neighbor block tag.',
+				description: 'The neighbor block tag which the component will test.',
 				type: 'string'
 			},
 			directions: {
-				description: 'Outlines which directions can be connected to.',
+				description: 'Specifies which direction the component will use & create block properties for.',
 				type: 'array',
 				items: {
 					type: 'string',
@@ -21,7 +21,7 @@ export default defineComponent(({ name, template, schema }) => {
 				}
 			},
 			parts: {
-				description: 'part_visiblity method | Defines when to hide specific parts of the geometry. Not compatible with the "geometries" method.',
+				description: 'The part_visiblity method | Defines when to hide specific parts of the geometry. Not compatible with the "geometries" method.',
 				type: 'object',
 				additionalProperties: false,
 				patternProperties: {
@@ -32,7 +32,7 @@ export default defineComponent(({ name, template, schema }) => {
 				}
 			},
 			geometries: {
-				description: 'geometries method | Defines a list of geometries and when to hide each one. Not compatible with the "part_visiblity" method.',
+				description: 'The geometries method | Defines a list of geometries and when to hide each one. Not compatible with the "part_visiblity" method.',
 				type: 'array',
 				items: {
 					type: 'object',
@@ -42,7 +42,7 @@ export default defineComponent(({ name, template, schema }) => {
 							type: 'string'
 						},
 						directions: {
-							description: 'When to show the geometry. Multiple directions can be passed.',
+							description: 'Specifies when to show the geometry. Multiple directions can be passed.',
 							type: 'array',
 							items: { enum: [ 'north', 'east', 'south', 'west', 'up', 'down' ] }
 						}
@@ -82,6 +82,7 @@ export default defineComponent(({ name, template, schema }) => {
 				)
 			}
 		}
+
 		if (geometries) {
 			create(
 				{

--- a/plugins/ConnectableBlock/components/block/connectable.ts
+++ b/plugins/ConnectableBlock/components/block/connectable.ts
@@ -22,12 +22,19 @@ export default defineComponent(({ name, template, schema }) => {
 			},
 			parts: {
 				description: 'The part_visiblity method | Defines when to hide specific parts of the geometry. Not compatible with the "geometries" method.',
-				type: 'object',
-				additionalProperties: false,
-				patternProperties: {
-					'^[a-z0-9_-]+$': {
-						description: 'Bone name.',
-						enum: [ 'north', 'east', 'south', 'west', 'up', 'down' ]
+				type: 'array',
+				items: {
+					type: 'object',
+					properties: {
+						name: {
+							description: 'Name of the bone.',
+							type: 'string'
+						},
+						directions: {
+							description: 'Specifies when to show the part. Multiple directions can be passed.',
+							type: 'array',
+							items: { enum: [ 'north', 'east', 'south', 'west', 'up', 'down' ] }
+						}
 					}
 				}
 			},
@@ -52,7 +59,7 @@ export default defineComponent(({ name, template, schema }) => {
 		}
 	})
 
-	template(({ tag, directions, parts = {}, geometries = [] }:{ tag: string, directions: string[], parts: any, geometries: any }, { create, identifier }) => {
+	template(({ tag, directions, parts = [], geometries = [] }:{ tag: string, directions: string[], parts: any, geometries: any }, { create }) => {
 
 		const positions = new Map([
 			[ 'north', [ 0, 0, -1 ] ],
@@ -73,14 +80,18 @@ export default defineComponent(({ name, template, schema }) => {
 		})
 
 		if (parts) {
-			for (const [bone, dir] of Object.entries(parts)) {
+			parts.map(part => {
 				create(
 					{
-						[bone]: `q.block_property('bridge:${dir}_neighbor')`
+						...(part.directions.length === 1 ? {
+							[part.name]: `q.block_property('bridge:${part.directions}_neighbor')`
+						} : {
+							[part.name]: `${part.directions.map((dir: string) => `q.block_property('bridge:${dir}_neighbor')`).join('&&')}`
+						})
 					},
 					'minecraft:block/components/minecraft:part_visibility/rules'
 				)
-			}
+			})
 		}
 
 		if (geometries) {

--- a/plugins/ConnectableBlock/components/block/connectable.ts
+++ b/plugins/ConnectableBlock/components/block/connectable.ts
@@ -52,6 +52,9 @@ export default defineComponent(({ name, template, schema }) => {
 							description: 'Specifies when to show the geometry. Multiple directions can be passed.',
 							type: 'array',
 							items: { enum: [ 'north', 'east', 'south', 'west', 'up', 'down' ] }
+						},
+						material_instances: {
+							$ref: '/data/packages/minecraftBedrock/schema/block/v1.16.100/components/material_instances.json'
 						}
 					}
 				}
@@ -104,7 +107,8 @@ export default defineComponent(({ name, template, schema }) => {
 							condition: `${geo.directions.map((dir: string) => `q.block_property('bridge:${dir}_neighbor')`).join('&&')}`
 						}),
 						components: {
-							'minecraft:geometry': geo.name
+							'minecraft:geometry': geo.name,
+							'minecraft:material_instances': geo.material_instances
 						}
 					}))
 				},

--- a/plugins/ConnectableBlock/manifest.json
+++ b/plugins/ConnectableBlock/manifest.json
@@ -2,7 +2,7 @@
 	"icon": "mdi-cube-outline",
 	"author": "Arexon",
 	"name": "Connectable Block",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"id": "8e362b9e-7c63-4495-b0ab-111fd31de00d",
 	"description": "Easily make your block connect with neighboring blocks by using part_visibity or geometries.",
 	"api_version": 2,


### PR DESCRIPTION
### Material instances
Added support for handling material instances in the geometries method:
```json
"bridge:connectable": {
	"tag": "pillar",
	"directions": [ "down", "up" ],
	"geometries": [
		{
			"name": "geometry.pillar_base",
			"directions": [ "up" ],
			"material_instances": {
				"*": {
					"texture": "pillar_base",
					"render_method": "opaque"
				}
			}
		},
		{
			"name": "geometry.pillar",
			"directions": [ "down" ],
			"material_instances": {
				"*": {
					"texture": "pillar",
					"render_method": "opaque"
				}
			}
		}
	]
}
```



### Parts method
Made major improvement to the parts method, allowing it to handle multiple directions:
```json
"bridge:connectable": {
	"tag": "pillar",
	"directions": [ "down", "up" ],
	"parts": [
		{
			"name": "pillar_base",
			"directions": [ "down", "up" ]
		}
	]
}
```