### PR TITLE
Added Templater Compiler Plugin

### DIFF
--- a/plugins/Templater/README.md
+++ b/plugins/Templater/README.md
@@ -25,14 +25,14 @@ If you have a supported file and want to make it a template, just add `"is_templ
 
 ```json
 {
-	"is_template": true,
-	"format_version": "...",
-	"minecraft:entity": {
+    "is_template": true,
+    "format_version": "...",
+    "minecraft:entity": {
         "description" : {
             "identifier" : "namespace:id"
         }
-		...
-	}
+        ...
+    }
 }
 ```
 
@@ -42,14 +42,14 @@ Then, if you want to instantiate that template in a file, add `"include" : "name
 
 ```json
 {
-	"include": "namespace:id",
-	"format_version": "...",
-	"minecraft:entity": {
-		"description": {
-			"identifier": "namespace:instance"
-		}
+    "include": "namespace:id",
+    "format_version": "...",
+    "minecraft:entity": {
+        "description": {
+            "identifier": "namespace:instance"
+        }
         ...
-   	}
+    }
 }		
 ```
 
@@ -57,17 +57,17 @@ You can even include multiple templates:
 
 ```json
 {
-	"include": [
-		"namespace:id1",
-		"namespace:id2",
-	],
-	"format_version": "...",
-	"minecraft:entity": {
-		"description": {
-			"identifier": "namespace:instance"
-		}
+    "include": [
+        "namespace:id1",
+        "namespace:id2"
+    ],
+    "format_version": "...",
+    "minecraft:entity": {
+        "description": {
+            "identifier": "namespace:instance"
+        }
         ...
-   	}
+    }
 }		
 ```
 
@@ -75,36 +75,36 @@ Order matters: if we have these two templates:
 
 ```json
 {
-	"is_template": true,
-	"format_version": "...",
-	"minecraft:entity": {
+    "is_template": true,
+    "format_version": "...",
+    "minecraft:entity": {
         "description" : {
             "identifier" : "namespace:id1"
-        }
-		"components" : {
-			"minecraft:foo" {
-				"bar" : 10
+        },
+        "components" : {
+            "minecraft:foo" : {
+                "bar" : 10
             }
-		}
-	}
+        }
+    }
 }
 ```
 
 ```json
 {
-	"is_template": true,
-	"format_version": "...",
-	"minecraft:entity": {
+    "is_template": true,
+    "format_version": "...",
+    "minecraft:entity": {
         "description" : {
             "identifier" : "namespace:id2"
-        }
-		"components" : {
-			"minecraft:foo" {
-				"bar" : 42
+        },
+        "components" : {
+            "minecraft:foo" : {
+                "bar" : 42
             },
-    		"minecraft:baz" : true
-		}
-	}
+            "minecraft:baz" : true
+        }
+    }
 }
 ```
 
@@ -112,19 +112,19 @@ Then the output of the example above will be:
 
 ```json
 {
-	"format_version": "...",
-	"minecraft:entity": {
-		"description": {
-			"identifier": "namespace:instance"
-		}
+    "format_version": "...",
+    "minecraft:entity": {
+        "description": {
+            "identifier": "namespace:instance"
+        },
         "components" : {
-			"minecraft:foo" {
-				"bar" : 10
+            "minecraft:foo" : {
+                "bar" : 10
             },
-    		"minecraft:baz" : true
-		}
-		...
-   	}
+            "minecraft:baz" : true
+        }
+        ...
+    }
 }	
 ```
 
@@ -132,7 +132,109 @@ The first one takes precedence.
 
 Templates can include other templates, but it is not recommended.
 
-## Future Plans
+## Variables
 
-I want to add support for custom variable instantiation, where an instanced file can define variables which will be replaced in the template.
+Templates support variables. For example a template could look like this:
 
+```json
+{
+    "is_template" : true,
+    "format_version": "...",
+    "minecraft:entity": {
+        "description": {
+            "identifier": "namespace:template"
+        },
+        "components" : {
+            "minecraft:foo" : {
+                "bar" : "${BAR_VAL}"
+            },
+            "minecraft:baz" : true,
+            "minecraft:some_property" : "${SOME_PROP}"
+        },
+        "events" : {
+            "${NAMESPACE}:${NAME}_init_event" : {
+                "add" : {
+                    ...
+                }
+            }
+        }
+    }
+}	
+```
+
+There are three variables that are always defined: `NAMESPACE`, which corresponds to the object (not necessarily project) namespace,
+`NAME`, which corresponds to the object name (string after the `:`), `IDENTIFIER`, which is just the full identifier of the object. 
+We can have any json type as a value for variables: primitives, objects or arrays. We can instantiate variables like this:
+
+```json
+{
+    "variables" : {
+        "BAR_VAL" : 42,
+        "SOME_PROP" : {
+            "thing" : true
+        }
+    },
+    "template" 
+    "format_version": "...",
+    "minecraft:entity": {
+        "description": {
+            "identifier": "namespace:instance"
+        }
+    }
+}	
+```
+
+The resulting file would be:
+
+
+```json
+{
+    "format_version": "...",
+    "minecraft:entity": {
+        "description": {
+            "identifier": "namespace:instance"
+        },
+        "components" : {
+            "minecraft:foo" : {
+                "bar" : 42
+            },
+            "minecraft:baz" : true,
+            "minecraft:some_property" : {
+                "thing" : true
+            }
+        },
+        "events" : {
+            "namespace:instance_init_event" : {
+                "add" : {
+                    ...
+                }
+            }
+        }
+    }
+}	
+```
+
+Templates can also include variables, and variables can be defined multiple times. However, only the variable value with the highest priority is used. The 1. Priority is always the
+instance file itself, then the included templates in order of appearance. The three predefined variables cannot be overwritten.
+
+Therefore, it is recommended that templates include default values for their variables, unless they're necessarily supposed to be customized. This could look like this:
+
+```json
+{
+    "is_template" : true,
+    "variables" : {
+        "HEALTH" : 20.0
+    },
+    "format_version": "...",
+    "minecraft:entity": {
+        "description": {
+            "identifier": "namespace:template"
+        },
+        "components" : {
+            "minecraft:health" : {
+                "value" : "${HEALTH}"
+            }
+        }
+    }
+}	
+```

--- a/plugins/Templater/README.md
+++ b/plugins/Templater/README.md
@@ -1,0 +1,138 @@
+# Templater Compiler Plugin
+
+## Description
+
+This compiler plugin can create templated files and instantiate them, greatly reducing code redundancy and providing an inheritance structure.
+
+## Installing
+
+1. Download the plugin from the Extension Store.
+
+2. Add `templater` to your compiler path by editing the project `config.json`. Depending on your purposes, you want to list it after `customXYZComponents`, because that will reduce file redundancy. If you do not care about that, you can have it after the `typeScript` plugin.
+
+## Supported File Types:
+
+- BP Entities
+- RP Entities
+- BP Blocks
+- BP Items
+- RP Items (technically supported, but bridge. doesn't seem to process the `transform` function for them for some reason)
+- RP Particles
+
+## Usage
+
+If you have a supported file and want to make it a template, just add `"is_template" : true` at the root project structure, like this:
+
+```json
+{
+	"is_template": true,
+	"format_version": "...",
+	"minecraft:entity": {
+        "description" : {
+            "identifier" : "namespace:id"
+        }
+		...
+	}
+}
+```
+
+It is important that the template has an identifier set.
+
+Then, if you want to instantiate that template in a file, add `"include" : "namespace:id"` at the project root structure, like this:
+
+```json
+{
+	"include": "namespace:id",
+	"format_version": "...",
+	"minecraft:entity": {
+		"description": {
+			"identifier": "namespace:instance"
+		}
+        ...
+   	}
+}		
+```
+
+You can even include multiple templates:
+
+```json
+{
+	"include": [
+		"namespace:id1",
+		"namespace:id2",
+	],
+	"format_version": "...",
+	"minecraft:entity": {
+		"description": {
+			"identifier": "namespace:instance"
+		}
+        ...
+   	}
+}		
+```
+
+Order matters: if we have these two templates:
+
+```json
+{
+	"is_template": true,
+	"format_version": "...",
+	"minecraft:entity": {
+        "description" : {
+            "identifier" : "namespace:id1"
+        }
+		"components" : {
+			"minecraft:foo" {
+				"bar" : 10
+            }
+		}
+	}
+}
+```
+
+```json
+{
+	"is_template": true,
+	"format_version": "...",
+	"minecraft:entity": {
+        "description" : {
+            "identifier" : "namespace:id2"
+        }
+		"components" : {
+			"minecraft:foo" {
+				"bar" : 42
+            },
+    		"minecraft:baz" : true
+		}
+	}
+}
+```
+
+Then the output of the example above will be:
+
+```json
+{
+	"format_version": "...",
+	"minecraft:entity": {
+		"description": {
+			"identifier": "namespace:instance"
+		}
+        "components" : {
+			"minecraft:foo" {
+				"bar" : 10
+            },
+    		"minecraft:baz" : true
+		}
+		...
+   	}
+}	
+```
+
+The first one takes precedence.
+
+Templates can include other templates, but it is not recommended.
+
+## Future Plans
+
+I want to add support for custom variable instantiation, where an instanced file can define variables which will be replaced in the template.
+

--- a/plugins/Templater/compiler/templater.js
+++ b/plugins/Templater/compiler/templater.js
@@ -1,0 +1,170 @@
+export default ({ options, fileType, packType, fileSystem, getAliases }) => {
+
+    //Merge function generously "borrowed" by Joel ant 05
+    function deepMerge(obj1, obj2) {
+        let outArray = undefined
+        if (Array.isArray(obj1) && Array.isArray(obj2)) outArray = obj1.concat(obj2)
+        else if (Array.isArray(obj1)) outArray = obj1.concat([obj2])
+        else if (Array.isArray(obj2)) outArray = obj2.concat([obj1])
+        else if (typeof obj2 !== 'object') return obj2
+
+        // Remove duplicates
+        if (outArray) return [...new Set([...outArray])]
+
+        let res = {}
+
+        for (const key in obj1) {
+            if (obj2[key] === undefined) res[key] = obj1[key]
+            else res[key] = deepMerge(obj1[key], obj2[key])
+        }
+
+        for (const key in obj2) {
+            if (obj1[key] === undefined) res[key] = obj2[key]
+        }
+
+        return res
+    }
+
+    function isTemplateable(filePath)
+    {
+        let type = fileType?.getId(filePath);
+        switch(type) {
+            case  "block" :
+            case  "entity" :
+            case  "item" :
+            case  "particle" :
+            case  "clientEntity" :
+            case  "clientItem" :  
+                return true;
+            default:
+                return false; 
+        }
+    }
+
+    function getIdentifier(filePath, fileContent)
+    {
+        let type = fileType?.getId(filePath);
+        switch(type) {
+            case  "block" :
+                return fileContent?.['minecraft:block']?.description?.identifier;
+            case  "entity" :
+                return fileContent?.['minecraft:entity']?.description?.identifier
+            case  "item" :
+            case  "clientItem" :  
+                return fileContent?.['minecraft:item']?.description?.identifier
+            case  "particle":
+                return fileContent?.['particle_effect']?.description?.identifier
+            case  "clientEntity" :
+                return fileContent?.['minecraft:client_entity']?.description?.identifier
+            default:
+                return; 
+        }
+    }
+
+    function isTemplate(filePath, fileContent)
+    {
+        return fileContent?.is_template && getIdentifier(filePath, fileContent);
+    }
+
+    function getInclude(fileContent)
+    {
+        let inc = fileContent?.include;
+        if(inc)
+        {
+            if(!Array.isArray(inc))
+                return [inc];
+                return inc;
+        }
+    }
+
+    function addTemplate(filePath, identifier, fileContent)
+    {
+        let id = fileType?.getId(filePath);
+        let e = templates[id] ?? {};
+        e[identifier] = fileContent;
+        templates[id] = e;
+    }
+
+    function mergeTemplate(filePath, entityJSON, templateEntity)
+    {
+        let id = fileType?.getId(filePath);
+        let templateGroup = templates[id];
+        let template = templateGroup?.[templateEntity];
+        if(template)
+            return deepMerge(template, entityJSON);
+        else 
+            return entityJSON;
+    }
+
+    function cleanup(fileContent)
+    {
+        delete fileContent?.include;
+        delete fileContent?.is_template;
+        return fileContent;
+    }
+
+    var templates = {};
+
+    return {
+
+        //Make sure template files do not get output in the build
+        async transformPath(filePath) {
+            if (isTemplateable(filePath)) {
+
+                let obj = await fileSystem.readJson(filePath);
+                
+                if(isTemplate(filePath, obj))
+                return null;
+            }
+        },
+        
+        //Same as EntityAliases plugin, do this just in case users don't have it installed
+        registerAliases(filePath, fileContent) {
+            let type = fileType?.getId(filePath);
+            if (
+                isTemplateable(filePath) &&
+                getIdentifier(filePath, fileContent)
+                )
+                return [
+                    `${getIdentifier(filePath, fileContent)}_${type}`
+                ]
+            },
+            
+            //Make entities that use templates depend on those templates
+        require(filePath, fileContent) {
+                if (isTemplateable(filePath)) {
+
+                let type = fileType?.getId(filePath);
+                let includes = getInclude(fileContent);
+
+                if (includes) {
+                    return Array.from(includes, i => `${i}_${type}`);
+                }
+            }
+        },
+
+        //Actually merge templates with entity files
+        async transform(filePath, fileContent) {
+            if (isTemplateable(filePath)) {
+
+                let tobj = fileContent;
+                let identifier = getIdentifier(filePath, tobj);
+                let isTemplateObj = isTemplate(filePath, tobj);
+                let includes = getInclude(tobj);
+
+                if (includes) {
+                    for(let i in includes)
+                        tobj = await mergeTemplate(filePath, tobj, includes[i]);
+                }
+
+                tobj = cleanup(tobj);
+
+                if(isTemplateObj)
+                    addTemplate(filePath, identifier, tobj);
+
+                return tobj;
+            }
+        },
+
+    }
+}

--- a/plugins/Templater/manifest.json
+++ b/plugins/Templater/manifest.json
@@ -1,0 +1,16 @@
+{
+	"author": "Tschipp",
+	"icon": "mdi-content-copy",
+	"name": "Templater",
+	"version": "1.0.0",
+	"id": "db2e968b-2d52-486b-bfec-a346395d4936",
+	"description": "Lets files be used as templates and inserted in other files, using inheritance structures",
+	"api_version": 2,
+	"target": "v2",
+	"tags": ["Compiler"],
+	"compiler": {
+		"plugins": {
+			"templater": "compiler/templater.js"
+		}
+	}
+}

--- a/plugins/Templater/manifest.json
+++ b/plugins/Templater/manifest.json
@@ -4,7 +4,7 @@
 	"name": "Templater",
 	"version": "1.0.0",
 	"id": "db2e968b-2d52-486b-bfec-a346395d4936",
-	"description": "Lets files be used as templates and inserted in other files, using inheritance structures",
+	"description": "Lets files be used as templates and inserted in other files, using inheritance structures. Docs: tschipp.ch/templater",
 	"api_version": 2,
 	"target": "v2",
 	"tags": ["Compiler"],


### PR DESCRIPTION
# Templater Compiler Plugin

## Description

This compiler plugin can create templated files and instantiate them, greatly reducing code redundancy and providing an inheritance structure.

## Supported File Types:

- BP Entities
- RP Entities
- BP Blocks
- BP Items
- RP Items (technically supported, but bridge. doesn't seem to process the `transform` function for them for some reason)
- RP Particles

## Usage

If you have a supported file and want to make it a template, just add `"is_template" : true` at the root project structure, like this:

```json
{
    "is_template": true,
    "format_version": "...",
    "minecraft:entity": {
        "description" : {
            "identifier" : "namespace:id"
        }
        ...
    }
}
```

It is important that the template has an identifier set.

Then, if you want to instantiate that template in a file, add `"include" : "namespace:id"` at the project root structure, like this:

```json
{
    "include": "namespace:id",
    "format_version": "...",
    "minecraft:entity": {
        "description": {
            "identifier": "namespace:instance"
        }
        ...
    }
}		
```

You can even include multiple templates:

```json
{
    "include": [
        "namespace:id1",
        "namespace:id2"
    ],
    "format_version": "...",
    "minecraft:entity": {
        "description": {
            "identifier": "namespace:instance"
        }
        ...
    }
}		
```

Order matters: if we have these two templates:

```json
{
    "is_template": true,
    "format_version": "...",
    "minecraft:entity": {
        "description" : {
            "identifier" : "namespace:id1"
        },
        "components" : {
            "minecraft:foo" : {
                "bar" : 10
            }
        }
    }
}
```

```json
{
    "is_template": true,
    "format_version": "...",
    "minecraft:entity": {
        "description" : {
            "identifier" : "namespace:id2"
        },
        "components" : {
            "minecraft:foo" : {
                "bar" : 42
            },
            "minecraft:baz" : true
        }
    }
}
```

Then the output of the example above will be:

```json
{
    "format_version": "...",
    "minecraft:entity": {
        "description": {
            "identifier": "namespace:instance"
        },
        "components" : {
            "minecraft:foo" : {
                "bar" : 10
            },
            "minecraft:baz" : true
        }
        ...
    }
}	
```

The first one takes precedence.

Templates can include other templates, but it is not recommended.

## Variables

Templates support variables. For example a template could look like this:

```json
{
    "is_template" : true,
    "format_version": "...",
    "minecraft:entity": {
        "description": {
            "identifier": "namespace:template"
        },
        "components" : {
            "minecraft:foo" : {
                "bar" : "${BAR_VAL}"
            },
            "minecraft:baz" : true,
            "minecraft:some_property" : "${SOME_PROP}"
        },
        "events" : {
            "${NAMESPACE}:${NAME}_init_event" : {
                "add" : {
                    ...
                }
            }
        }
    }
}	
```

There are three variables that are always defined: `NAMESPACE`, which corresponds to the object (not necessarily project) namespace,
`NAME`, which corresponds to the object name (string after the `:`), `IDENTIFIER`, which is just the full identifier of the object. 
We can have any json type as a value for variables: primitives, objects or arrays. We can instantiate variables like this:

```json
{
    "variables" : {
        "BAR_VAL" : 42,
        "SOME_PROP" : {
            "thing" : true
        }
    },
    "template" 
    "format_version": "...",
    "minecraft:entity": {
        "description": {
            "identifier": "namespace:instance"
        }
    }
}	
```

The resulting file would be:


```json
{
    "format_version": "...",
    "minecraft:entity": {
        "description": {
            "identifier": "namespace:instance"
        },
        "components" : {
            "minecraft:foo" : {
                "bar" : 42
            },
            "minecraft:baz" : true,
            "minecraft:some_property" : {
                "thing" : true
            }
        },
        "events" : {
            "namespace:instance_init_event" : {
                "add" : {
                    ...
                }
            }
        }
    }
}	
```

Templates can also include variables, and variables can be defined multiple times. However, only the variable value with the highest priority is used. The 1. Priority is always the
instance file itself, then the included templates in order of appearance. The three predefined variables cannot be overwritten.

Therefore, it is recommended that templates include default values for their variables, unless they're necessarily supposed to be customized. This could look like this:

```json
{
    "is_template" : true,
    "variables" : {
        "HEALTH" : 20.0
    },
    "format_version": "...",
    "minecraft:entity": {
        "description": {
            "identifier": "namespace:template"
        },
        "components" : {
            "minecraft:health" : {
                "value" : "${HEALTH}"
            }
        }
    }
}	
```