### PR TITLE
Remove "minecraft:unwalkable"

### DIFF
--- a/plugins/WoodTypePreset/manifest.json
+++ b/plugins/WoodTypePreset/manifest.json
@@ -2,7 +2,7 @@
 	"icon": "mdi-palm-tree",
 	"author": "gekocaretaker",
 	"id": "b607f993-52a0-498d-a0a0-3ea12583d05a",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"name": "Wood Type Preset",
 	"target": "v2",
 	"readme": "https://github.com/bridge-core/plugins/tree/master/plugins/WoodTypePreset",

--- a/plugins/WoodTypePreset/presets/wood_type/fence.json
+++ b/plugins/WoodTypePreset/presets/wood_type/fence.json
@@ -85,7 +85,6 @@
                     "event": "e:update.neighbors"
                 }
             },
-            "minecraft:unwalkable": true,
             "minecraft:on_player_placing": {
                 "event": "bridge:create_fence"
             },

--- a/plugins/WoodTypePreset/presets/wood_type/fence_gate.json
+++ b/plugins/WoodTypePreset/presets/wood_type/fence_gate.json
@@ -36,7 +36,6 @@
                 "group": "itemGroup.name.fenceGate"
             },
             "minecraft:geometry": "geometry.custom_fence_gate",
-            "minecraft:unwalkable": true,
             "minecraft:breathability": "air",
             "minecraft:on_player_placing": {
                 "event": "bridge:update_rotation"


### PR DESCRIPTION
This component was removed 1.19.20.23 (https://feedback.minecraft.net/hc/en-us/articles/7814091998989-Minecraft-Beta-Preview-1-19-20-23) This change it made to prevent the fence and gate blocks from breaking upon this change being brought to full release.