### PR TITLE
ConnectableBlock - Update component names for 1.19.50

### DIFF
--- a/plugins/ConnectableBlock/components/block/connectable.ts
+++ b/plugins/ConnectableBlock/components/block/connectable.ts
@@ -92,7 +92,7 @@ export default defineComponent(({ name, template, schema }) => {
 							[part.name]: `${part.directions.map((dir: string) => `q.block_property('bridge:${dir}_neighbor')`).join('&&')}`
 						})
 					},
-					'minecraft:block/components/minecraft:part_visibility/rules'
+					'minecraft:block/components/minecraft:part_visibility/conditions'
 				)
 			})
 		}
@@ -118,9 +118,9 @@ export default defineComponent(({ name, template, schema }) => {
 
 		create(
 			{
-				'minecraft:ticking': {
+				'minecraft:queued_ticking': {
 					looping: true,
-					range: [ 0, 0 ],
+					interval_range: [ 0, 0 ],
 					on_tick: {
 						event: 'e:update.neighbors'
 					}

--- a/plugins/ConnectableBlock/manifest.json
+++ b/plugins/ConnectableBlock/manifest.json
@@ -2,7 +2,7 @@
 	"icon": "mdi-cube-outline",
 	"author": "Arexon",
 	"name": "Connectable Block",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"id": "8e362b9e-7c63-4495-b0ab-111fd31de00d",
 	"description": "Easily make your block connect with neighboring blocks by using part_visibity or geometries.",
 	"api_version": 2,


### PR DESCRIPTION
I found that some keys have changed names in 1.19.50 so the components didn't work. Just updated the names.

Testing: ran with an add-on I'm working on and saw blocks connecting.